### PR TITLE
Hotfix for zone_redundancy oneOf schema

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -96,9 +96,6 @@ params:
                         zone_redundancy:
                           const: true
                         replication_type:
-                          title: Replication type
-                          description: The type of replication to use for the storage account.
-                          type: string
                           oneOf:
                             - title: Zone-redundant storage
                               const: ZRS
@@ -110,9 +107,6 @@ params:
                         zone_redundancy:
                           const: false
                         replication_type:
-                          title: Replication type
-                          description: The type of replication to use for the storage account.
-                          type: string
                           oneOf:
                             - title: Local-redundant storage
                               const: LRS
@@ -131,9 +125,6 @@ params:
             redundancy:
               properties:
                 replication_type:
-                  title: Replication type
-                  description: The type of replication to use for the storage account.
-                  type: string
                   oneOf:
                     - title: Local-redundant storage
                       const: LRS
@@ -141,6 +132,37 @@ params:
                       const: GRS
                     - title: Geo-redundant storage (read-access)
                       const: RAGRS
+  allOf:
+    - if:
+        properties:
+          redundancy:
+            properties:
+              zone_redundancy:
+                const: true
+      then:
+        properties:
+          redundancy:
+            properties:
+              replication_type:
+                oneOf:
+                  - title: Zone-redundant storage
+                    const: ZRS
+                  - title: Geo-zone-redundant storage
+                    const: GZRS
+                  - title: Geo-zone-redundant storage (read-access)
+                    const: RAGZRS
+      else:
+        properties:
+          redundancy:
+            properties:
+              replication_type:
+                oneOf:
+                  - title: Local-redundant storage
+                    const: LRS
+                  - title: Geo-redundant storage
+                    const: GRS
+                  - title: Geo-redundant storage (read-access)
+                    const: RAGRS
 
 connections:
   required:


### PR DESCRIPTION
Seeing this error when trying to deploy a storage account using zone redundancy:
![image](https://user-images.githubusercontent.com/8037512/190275648-5259e090-3ef9-4846-8322-13be36840b18.png)

Made some changes to fix a UI presentation bug and ended up breaking the oneOf schema for `zone_redundancy`. In my testing with RJSF, there was no issue beforehand. I don't see any errors in RJSF with this build either, so it's sort of trial-and-error on fixing this.