### PR TITLE
Updating latency to a higher value before alarm

### DIFF
--- a/src/monitoring.tf
+++ b/src/monitoring.tf
@@ -7,7 +7,7 @@ locals {
   metric_config = {
     operator_latency  = "GreaterThan"
     aggregation       = "Average"
-    threshold_latency = 500
+    threshold_latency = 250
   }
 }
 


### PR DESCRIPTION
Currently storage accounts in our UI are deploying to with an average latency of 168. Bumping up our tolerance to 500 for now.