### PR TITLE
Fix disabling optional alarms

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -67,7 +67,7 @@ MonitorAlarmMetric: &monitor_alarm_metric
         - title: Every 12 hours
           const: PT12H
         - title: Every 24 hours
-          const: PT1D
+          const: P1D
     aggregation:
       title: Aggregation
       description: The aggregation type of the alarm.

--- a/src/monitoring.tf
+++ b/src/monitoring.tf
@@ -30,7 +30,8 @@ locals {
     "DISABLED"  = {}
     "CUSTOM"    = lookup(var.monitoring, "alarms", {})
   }
-  alarms = lookup(local.alarms_map, var.monitoring.mode, {})
+  alarms             = lookup(local.alarms_map, var.monitoring.mode, {})
+  monitoring_enabled = var.monitoring.mode != "DISABLED" ? 1 : 0
 }
 
 module "alarm_channel" {
@@ -40,6 +41,7 @@ module "alarm_channel" {
 }
 
 module "availability_metric_alert" {
+  count                   = local.monitoring_enabled
   source                  = "github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm?ref=40d6e54"
   scopes                  = [azurerm_storage_account.main.id]
   resource_group_name     = azurerm_resource_group.main.name
@@ -65,6 +67,7 @@ module "availability_metric_alert" {
 }
 
 module "success_e2e_latency_metric_alert" {
+  count                   = local.monitoring_enabled
   source                  = "github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm?ref=40d6e54"
   scopes                  = [azurerm_storage_account.main.id]
   resource_group_name     = azurerm_resource_group.main.name
@@ -90,6 +93,7 @@ module "success_e2e_latency_metric_alert" {
 }
 
 module "success_server_latency_metric_alert" {
+  count                   = local.monitoring_enabled
   source                  = "github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm?ref=40d6e54"
   scopes                  = [azurerm_storage_account.main.id]
   resource_group_name     = azurerm_resource_group.main.name


### PR DESCRIPTION
Closes: https://github.com/massdriver-cloud/azure-storage-account-application-assets/issues/17

https://linear.app/massdriver/issue/ORC-161/picking-disabled-alarms-causing-provisioning-failure

Tested using local deployment and personal org deployment