### PR TITLE
Removed VNet integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mclacore @WillBeebe
+@mclacore

--- a/operator.mdx
+++ b/operator.mdx
@@ -29,8 +29,6 @@ Our bundle includes the following design choices to help simplify your deploymen
 Azure Storage always stores multiple copies of your data so that it's protected from planned and unplanned events, including transient hardware failures, network or power outages, and massive natural disasters. Redundancy ensures that your storage account meets its availability and durability targets even in the face of failures.
 * Locally redundant storage (LRS) copies your data synchronously three times within a single physical location in the primary region. LRS is the least expensive replication option, but isn't recommended for applications requiring high availability or durability.
 * Zone-redundant storage (ZRS) copies your data synchronously across three Azure availability zones in the primary region. For applications requiring high availability, Microsoft recommends using ZRS in the primary region, and also replicating to a secondary region.
-### Virtual network integration
-A private endpoint is created and connected to your VNet so other resources within the VNet can read/write to the storage account.
 
 ## Best Practices
 The bundle includes a number of best practices without needing any additional work on your part.
@@ -41,8 +39,6 @@ A time-based retention policy stores blob data in a Write-Once, Read-Many (WORM)
 
 ## Security
 In order to improve security, we implement a few key safeguards.
-### Private endpoints
-Public network access is disabled for this storage account. For network connectivity, we rely on private endpoints to allow clients on a Vnet securely access data within the storage account over a private link.
 ### Data encrypted in transit
 By default, all data in transit will be encrypted with Secure Sockets Layer and Transport Layer Security (SSL/TLS).
 ### Data encrypted at rest


### PR DESCRIPTION
VNet integration was removed because it was requiring all connections to go over VPN if they were external to the VNet, like uploading assets to the storage account.